### PR TITLE
feat: init implementation of content provider inline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,32 +3,32 @@ version: 2.1
 setup: true
 
 orbs:
-  gravitee: gravitee-io/gravitee@4.1.1
+    gravitee: gravitee-io/gravitee@4.1.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
 workflows:
-  setup_build:
-    when:
-      not: << pipeline.git.tag >>
-    jobs:
-      - gravitee/setup_plugin-build-config:
-          filters:
-            tags:
-              ignore:
-                - /.*/
+    setup_build:
+        when:
+            not: << pipeline.git.tag >>
+        jobs:
+            - gravitee/setup_plugin-build-config:
+                  filters:
+                      tags:
+                          ignore:
+                              - /.*/
 
-  setup_release:
-    when:
-      matches:
-        pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
-        value: << pipeline.git.tag >>
-    jobs:
-      - gravitee/setup_plugin-release-config:
-          filters:
-            branches:
-              ignore:
-                - /.*/
-            tags:
-              only:
-                - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/
+    setup_release:
+        when:
+            matches:
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
+                value: << pipeline.git.tag >>
+        jobs:
+            - gravitee/setup_plugin-release-config:
+                  filters:
+                      branches:
+                          ignore:
+                              - /.*/
+                      tags:
+                          only:
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["github>gravitee-io/renovate-config:policy"]
+    "extends": ["github>gravitee-io/renovate-config:policy"]
 }

--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -1,0 +1,217 @@
+====
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+====
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.adoc
+++ b/README.adoc
@@ -1,1 +1,53 @@
-# gravitee-resource-content-provider-inline
+= Resource SContent Provider API
+
+image:https://img.shields.io/badge/License-Apache%202.0-blue.svg["License", link="https://github.com/gravitee-io/gravitee-resource-content-provider-api/blob/main/LICENSE.txt"]
+image:https://img.shields.io/badge/semantic--release-conventional%20commits-e10079?logo=semantic-release["Releases", link="https://github.com/gravitee-io/gravitee-resource-content-provider-api/releases"]
+image:https://circleci.com/gh/gravitee-io/gravitee-resource-content-provider-api.svg?style=svg["CircleCI", link="https://circleci.com/gh/gravitee-io/gravitee-resource-content-provider-api"]
+image:https://f.hubspotusercontent40.net/hubfs/7600448/gravitee-github-button.jpg["Join the community forum", link="https://community.gravitee.io?utm_source=readme", height=20]
+
+
+== Description
+Inline Content Provider Resource is used to store a data and provide it to a compatible policy.
+
+== Configuration
+You can configure the resource with the following options:
+
+|===
+|Property |Required |Description |Type |Default
+
+.^|name
+^.^|X
+|The name of the content provider.
+^.^|string
+^.^|my-content-provider
+
+
+.^|content
+^.^|X
+|The content to store
+^.^|integer
+^.^|
+
+.^|attributes
+^.^|X
+|An array of key value pairs that can be used by a resource consumer.
+^.^|object
+^.^|
+
+|===
+
+[source, json]
+.Configuration example
+----
+{
+    "name": "content-resource",
+    "type": "content-provider-inline-resource",
+    "enabled": true,
+    "configuration": {
+        "content": "The content provided by the resource",
+        "attributes": {
+            "key": "value"
+        }
+    }
+}
+----

--- a/assembly/resource-assembly.xml
+++ b/assembly/resource-assembly.xml
@@ -1,0 +1,74 @@
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+    <id>resource</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+
+    <!-- Include the main Policy Jar file -->
+    <files>
+        <file>
+            <source>${project.build.directory}/${project.build.finalName}.jar</source>
+        </file>
+    </files>
+
+    <fileSets>
+        <!-- Then include Policy configuration schemas -->
+        <fileSet>
+            <directory>src/main/resources/schemas</directory>
+            <outputDirectory>schemas</outputDirectory>
+        </fileSet>
+
+        <fileSet>
+            <directory>${basedir}</directory>
+            <includes>
+                <include>README.adoc</include>
+            </includes>
+            <outputDirectory>docs</outputDirectory>
+        </fileSet>
+
+        <fileSet>
+            <directory>${basedir}</directory>
+            <includes>
+                <include>${icon}</include>
+            </includes>
+        </fileSet>
+
+        <!-- Create the empty lib directory in case of no libraries is required -->
+        <!-- As there is no maven-assembly-plugin's method do to that, we hack it ourself -->
+        <fileSet>
+            <directory>${project.basedir}/src/assembly</directory>
+            <outputDirectory>lib</outputDirectory>
+            <excludes>
+                <exclude>*</exclude>
+            </excludes>
+        </fileSet>
+    </fileSets>
+
+    <!-- Finally include Policy dependencies -->
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>lib</outputDirectory>
+            <useProjectArtifact>false</useProjectArtifact>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee</groupId>
+        <artifactId>gravitee-parent</artifactId>
+        <version>22.1.1</version>
+    </parent>
+
+    <groupId>io.gravitee.resource</groupId>
+    <artifactId>gravitee-resource-content-provider-inline</artifactId>
+    <version>1.0.0-alpha.0</version>
+
+    <name>Gravitee.io APIM - Resource - Content Provider Inline</name>
+
+    <properties>
+        <gravitee-bom.version>8.1.0</gravitee-bom.version>
+        <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
+        <gravitee-resource-content-provider-api.version>1.0.0-alpha.1</gravitee-resource-content-provider-api.version>
+        <maven-plugin-javadoc.version>3.4.1</maven-plugin-javadoc.version>
+
+        <!-- Property used by the publication job in CI-->
+        <publish-folder-path>graviteeio-apim/plugins/resources</publish-folder-path>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Import bom to properly inherit all dependencies -->
+            <dependency>
+                <groupId>io.gravitee</groupId>
+                <artifactId>gravitee-bom</artifactId>
+                <version>${gravitee-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- Gravitee.io API-->
+        <dependency>
+            <groupId>io.gravitee.resource</groupId>
+            <artifactId>gravitee-resource-api</artifactId>
+            <version>${gravitee-resource-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.resource</groupId>
+            <artifactId>gravitee-resource-content-provider-api</artifactId>
+            <version>${gravitee-resource-content-provider-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Other -->
+        <dependency>
+            <groupId>io.reactivex.rxjava3</groupId>
+            <artifactId>rxjava</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven-plugin-javadoc.version}</version>
+                <configuration>
+                    <additionalJOption>-Xdoclint:none</additionalJOption>
+                    <source>17</source>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.hubspot.maven.plugins</groupId>
+                <artifactId>prettier-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/io/gravitee/resource/content_provider/inline/ContentProviderInlineResource.java
+++ b/src/main/java/io/gravitee/resource/content_provider/inline/ContentProviderInlineResource.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.content_provider.inline;
+
+import io.gravitee.resource.content_provider.api.Content;
+import io.gravitee.resource.content_provider.api.ContentProviderResource;
+import io.gravitee.resource.content_provider.inline.configuration.ContentProviderInlineResourceConfiguration;
+import io.reactivex.rxjava3.core.Maybe;
+
+public class ContentProviderInlineResource extends ContentProviderResource<String, ContentProviderInlineResourceConfiguration> {
+
+    @Override
+    public Maybe<Content<String>> getContent() {
+        return configuration().hasContent()
+            ? Maybe.just(new InlineContent(configuration().getContent(), configuration().getAttributes()))
+            : Maybe.empty();
+    }
+}

--- a/src/main/java/io/gravitee/resource/content_provider/inline/InlineContent.java
+++ b/src/main/java/io/gravitee/resource/content_provider/inline/InlineContent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.content_provider.inline;
+
+import io.gravitee.resource.content_provider.api.Content;
+import io.gravitee.resource.content_provider.inline.configuration.Attribute;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.Getter;
+
+@Getter
+public class InlineContent implements Content<String> {
+
+    private final String content;
+    private final Map<String, Object> attributes;
+
+    public InlineContent(String content, List<Attribute> attributes) {
+        this.content = content;
+        if (attributes == null || attributes.isEmpty()) {
+            this.attributes = Map.of();
+        } else {
+            this.attributes = attributes.stream().collect(Collectors.toMap(Attribute::key, Attribute::value));
+        }
+    }
+}

--- a/src/main/java/io/gravitee/resource/content_provider/inline/configuration/Attribute.java
+++ b/src/main/java/io/gravitee/resource/content_provider/inline/configuration/Attribute.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.content_provider.inline.configuration;
+
+public record Attribute(String key, String value) {}

--- a/src/main/java/io/gravitee/resource/content_provider/inline/configuration/ContentProviderInlineResourceConfiguration.java
+++ b/src/main/java/io/gravitee/resource/content_provider/inline/configuration/ContentProviderInlineResourceConfiguration.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.content_provider.inline.configuration;
+
+import io.gravitee.resource.api.ResourceConfiguration;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContentProviderInlineResourceConfiguration implements ResourceConfiguration {
+
+    private String content;
+    private List<Attribute> attributes;
+
+    public boolean hasContent() {
+        return content != null && !content.isEmpty();
+    }
+}

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -1,0 +1,8 @@
+id=content-provider-inline-resource
+name=Content Provider Inline Resource
+version=${project.version}
+description=${project.description}
+class=io.gravitee.resource.content_provider.inline
+type=resource
+category=
+icon=

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "definitions": {
+        "_content": {
+            "type": "string",
+            "title": "Content",
+            "description": "The content to provide"
+        },
+        "_attributes": {
+            "type": "array",
+            "title": "Attributes",
+            "description": "List of attributes as key value pairs",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "title": "Key"
+                    },
+                    "value": {
+                        "type": "string",
+                        "title": "Value"
+                    }
+                },
+                "required": ["key", "value"]
+            }
+        }
+    },
+    "oneOf": [
+        {
+            "title": "Content",
+            "properties": {
+                "content": { "$ref": "#/definitions/_content" },
+                "attributes": { "$ref": "#/definitions/_attributes" }
+            },
+            "required": ["content"]
+        }
+    ]
+}

--- a/src/test/java/io/gravitee/resource/content_provider/inline/ContentProviderInlineResourceTest.java
+++ b/src/test/java/io/gravitee/resource/content_provider/inline/ContentProviderInlineResourceTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.content_provider.inline;
+
+import static io.gravitee.resource.content_provider.inline.configuration.ContentAndAttributesTestConfiguration.MY_AWESOME_CONTENT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.resource.content_provider.inline.configuration.Attribute;
+import io.gravitee.resource.content_provider.inline.configuration.ContentAndAttributesTestConfiguration;
+import io.gravitee.resource.content_provider.inline.configuration.ContentAndNoAttributesTestConfiguration;
+import io.gravitee.resource.content_provider.inline.configuration.ContentProviderInlineResourceConfiguration;
+import io.gravitee.resource.content_provider.inline.configuration.EmptyContentTestConfiguration;
+import io.gravitee.resource.content_provider.inline.configuration.NullContentTestConfiguration;
+import io.gravitee.resource.content_provider.inline.configuration.ResourceTestConfiguration;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ContentProviderInlineResourceTest {
+
+    @Nested
+    @ExtendWith(SpringExtension.class)
+    @ContextConfiguration(classes = { ResourceTestConfiguration.class, EmptyContentTestConfiguration.class })
+    class EmptyContent {
+
+        @Autowired
+        ContentProviderInlineResource cut;
+
+        @Test
+        void should_get_empty() {
+            final ContentProviderInlineResourceConfiguration configuration = cut.configuration();
+            assertThat(configuration.getContent()).isEmpty();
+            assertThat(configuration.getAttributes()).isEmpty();
+            cut.getContent().test().assertNoValues();
+        }
+    }
+
+    @Nested
+    @ExtendWith(SpringExtension.class)
+    @ContextConfiguration(classes = { ResourceTestConfiguration.class, NullContentTestConfiguration.class })
+    class NullContent {
+
+        @Autowired
+        ContentProviderInlineResource cut;
+
+        @Test
+        void should_get_empty() {
+            final ContentProviderInlineResourceConfiguration configuration = cut.configuration();
+            assertThat(configuration.getContent()).isNull();
+            assertThat(configuration.getAttributes()).isNull();
+            cut.getContent().test().assertNoValues();
+        }
+    }
+
+    @Nested
+    @ExtendWith(SpringExtension.class)
+    @ContextConfiguration(classes = { ResourceTestConfiguration.class, ContentAndAttributesTestConfiguration.class })
+    class ContentAndAttributes {
+
+        @Autowired
+        ContentProviderInlineResource cut;
+
+        @Test
+        void should_get_content() {
+            final ContentProviderInlineResourceConfiguration configuration = cut.configuration();
+            assertThat(configuration.getContent()).isEqualTo(MY_AWESOME_CONTENT);
+            assertThat(configuration.getAttributes()).containsExactly(new Attribute("key", "value"));
+            cut
+                .getContent()
+                .test()
+                .assertValue(value -> {
+                    assertThat(value.getContent()).isEqualTo(MY_AWESOME_CONTENT);
+                    assertThat(value.getAttributes()).containsExactlyEntriesOf(Map.of("key", "value"));
+                    return true;
+                });
+        }
+    }
+
+    @Nested
+    @ExtendWith(SpringExtension.class)
+    @ContextConfiguration(classes = { ResourceTestConfiguration.class, ContentAndNoAttributesTestConfiguration.class })
+    class ContentAndNoAttributes {
+
+        @Autowired
+        ContentProviderInlineResource cut;
+
+        @Test
+        void should_get_content() {
+            final ContentProviderInlineResourceConfiguration configuration = cut.configuration();
+            assertThat(configuration.getContent()).isEqualTo(MY_AWESOME_CONTENT);
+            assertThat(configuration.getAttributes()).isNull();
+            cut
+                .getContent()
+                .test()
+                .assertValue(value -> {
+                    assertThat(value.getContent()).isEqualTo(MY_AWESOME_CONTENT);
+                    assertThat(value.getAttributes()).isEmpty();
+                    return true;
+                });
+        }
+    }
+}

--- a/src/test/java/io/gravitee/resource/content_provider/inline/configuration/ContentAndAttributesTestConfiguration.java
+++ b/src/test/java/io/gravitee/resource/content_provider/inline/configuration/ContentAndAttributesTestConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.content_provider.inline.configuration;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ContentAndAttributesTestConfiguration {
+
+    public static final String MY_AWESOME_CONTENT = "my-awesome-content";
+
+    @Bean
+    ContentProviderInlineResourceConfiguration contentProviderInlineResourceConfiguration() {
+        return new ContentProviderInlineResourceConfiguration(MY_AWESOME_CONTENT, List.of(new Attribute("key", "value")));
+    }
+}

--- a/src/test/java/io/gravitee/resource/content_provider/inline/configuration/ContentAndNoAttributesTestConfiguration.java
+++ b/src/test/java/io/gravitee/resource/content_provider/inline/configuration/ContentAndNoAttributesTestConfiguration.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.content_provider.inline.configuration;
+
+import java.util.Map;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ContentAndNoAttributesTestConfiguration {
+
+    public static final String MY_AWESOME_CONTENT = "my-awesome-content";
+
+    @Bean
+    ContentProviderInlineResourceConfiguration contentProviderInlineResourceConfiguration() {
+        return new ContentProviderInlineResourceConfiguration(MY_AWESOME_CONTENT, null);
+    }
+}

--- a/src/test/java/io/gravitee/resource/content_provider/inline/configuration/EmptyContentTestConfiguration.java
+++ b/src/test/java/io/gravitee/resource/content_provider/inline/configuration/EmptyContentTestConfiguration.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.content_provider.inline.configuration;
+
+import java.util.HashMap;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class EmptyContentTestConfiguration {
+
+    @Bean
+    ContentProviderInlineResourceConfiguration contentProviderInlineResourceConfiguration() {
+        return new ContentProviderInlineResourceConfiguration("", List.of());
+    }
+}

--- a/src/test/java/io/gravitee/resource/content_provider/inline/configuration/NullContentTestConfiguration.java
+++ b/src/test/java/io/gravitee/resource/content_provider/inline/configuration/NullContentTestConfiguration.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.content_provider.inline.configuration;
+
+import java.util.HashMap;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class NullContentTestConfiguration {
+
+    @Bean
+    ContentProviderInlineResourceConfiguration contentProviderInlineResourceConfiguration() {
+        return new ContentProviderInlineResourceConfiguration(null, null);
+    }
+}

--- a/src/test/java/io/gravitee/resource/content_provider/inline/configuration/ResourceTestConfiguration.java
+++ b/src/test/java/io/gravitee/resource/content_provider/inline/configuration/ResourceTestConfiguration.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.content_provider.inline.configuration;
+
+import io.gravitee.resource.content_provider.inline.ContentProviderInlineResource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ResourceTestConfiguration {
+
+    @Bean
+    ContentProviderInlineResource contentProviderInlineResource() {
+        return new ContentProviderInlineResource();
+    }
+}


### PR DESCRIPTION


**Issue**

https://gravitee.atlassian.net/browse/APIM-5374

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-apim-5374-oas-validation-resource-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-content-provider-inline/1.0.0-apim-5374-oas-validation-resource-SNAPSHOT/gravitee-resource-content-provider-inline-1.0.0-apim-5374-oas-validation-resource-SNAPSHOT.zip)
  <!-- Version placeholder end -->
