### PR TITLE
feat: rework schema-form to use new GioJsonSchema Ui component

### DIFF
--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -5,3 +5,4 @@ description=${project.description}
 class=io.gravitee.resource.content_provider.inline.ContentProviderInlineResource
 type=resource
 icon=content-provider-inline-resource.svg
+category=Others

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,22 +1,12 @@
 {
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
-    "id": "urn:jsonschema:io:gravitee:resource:cache:configuration:CacheResourceConfiguration",
     "properties": {
         "content": {
             "type": "string",
             "title": "Content",
             "description": "The content to provide",
-            "x-schema-form": {
-                "type": "codemirror",
-                "codemirrorOptions": {
-                    "placeholder": "Put inline content here",
-                    "lineWrapping": true,
-                    "lineNumbers": true,
-                    "allowDropFileTypes": true,
-                    "autoCloseTags": true
-                },
-                "expression-language": false
-            }
+            "format": "gio-code-editor"
         },
         "attributes": {
             "type": "array",


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2212

**Description**

![image](https://github.com/gravitee-io/gravitee-resource-content-provider-inline/assets/4974420/76d64adf-f311-4034-8692-368183f49e85)


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-APIM-2364-json-schema-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-content-provider-inline/1.0.0-APIM-2364-json-schema-SNAPSHOT/gravitee-resource-content-provider-inline-1.0.0-APIM-2364-json-schema-SNAPSHOT.zip)
  <!-- Version placeholder end -->
