### PR TITLE
bump gravitee-resource-content-provider-api to 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <properties>
         <gravitee-bom.version>8.1.9</gravitee-bom.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
-        <gravitee-resource-content-provider-api.version>1.0.0-alpha.1</gravitee-resource-content-provider-api.version>
+        <gravitee-resource-content-provider-api.version>1.0.0</gravitee-resource-content-provider-api.version>
         <maven-plugin-javadoc.version>3.10.0</maven-plugin-javadoc.version>
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
         <maven-properties-plugin.version>1.2.1</maven-properties-plugin.version>


### PR DESCRIPTION
**Issue**
n/a

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.1-chore-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-content-provider-inline/1.1.1-chore-SNAPSHOT/gravitee-resource-content-provider-inline-1.1.1-chore-SNAPSHOT.zip)
  <!-- Version placeholder end -->
